### PR TITLE
Add script to run on Linux NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ Browser for plasmids search.
 **Technological Stack**: Python, PostgreSQL, Django, Flask, FastAPI, ...   
 
 
+# Linux (Nix or NixOs)
+
+To run the script:
+```
+nix-shell
+python 'Addgene parser.py'
+```

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  my-python-packages = ps: with ps; [
+    pandas
+    requests
+    beautifulsoup4
+    numpy    
+    # other python packages
+  ];
+  my-python = pkgs.python3.withPackages my-python-packages;
+in my-python.env


### PR DESCRIPTION
The PR adds `shell.nix` file that contains description of Python environment with libraries required to execute the parser without global installation.
